### PR TITLE
Fix undefined className in log message

### DIFF
--- a/karman-core/src/main/groovy/com/bertramlabs/plugins/karman/KarmanProviders.groovy
+++ b/karman-core/src/main/groovy/com/bertramlabs/plugins/karman/KarmanProviders.groovy
@@ -65,8 +65,8 @@ class KarmanProviders {
 				providerProperties.load(res.openStream())
 
 				providerProperties.keySet().each { providerName ->
+					String className = providerProperties.getProperty(providerName)
 					try {
-						String className = providerProperties.getProperty(providerName)
 						def cls = classLoader.loadClass(className)
 						if(NetworkProviderInterface.isAssignableFrom(cls)) {
 							if(!networkProviders[providerName]) {


### PR DESCRIPTION
Command [`log.error("Error Loading Karman Network Provider $className: $e.message",e)`](https://github.com/bertramdev/karman-core/blob/551171bb294b6fcde1af77fbb93c94129e8b9227/karman-core/src/main/groovy/com/bertramlabs/plugins/karman/KarmanProviders.groovy#L79) fails because [`className`](https://github.com/bertramdev/karman-core/blob/551171bb294b6fcde1af77fbb93c94129e8b9227/karman-core/src/main/groovy/com/bertramlabs/plugins/karman/KarmanProviders.groovy#L69) is undefined in catch block.