### PR TITLE
Signed Int Limits File Sizes to < 2^31 bytes

### DIFF
--- a/karman-azure/src/main/groovy/com/bertramlabs/plugins/karman/azure/AzurePageBlobFile.groovy
+++ b/karman-azure/src/main/groovy/com/bertramlabs/plugins/karman/azure/AzurePageBlobFile.groovy
@@ -233,7 +233,7 @@ class AzurePageBlobFile extends CloudFile {
 			ChunkedInputStream chunkedStream = new ChunkedInputStream(writeStream, partSize)
 			long filePosition = 0
 			int partNumber = 1
-			int startByte = 0
+			long startByte = 0
 			while(chunkedStream.available() >= 0 && (!contentLength || filePosition < contentLength)) {
 				// Last part can be less than 5 MB. Adjust part size.
 				


### PR DESCRIPTION
A signed integer is incorrectly used here and cause an overflow that fails after 2GB of a file is processed.